### PR TITLE
Fix locale overrides using inactive language

### DIFF
--- a/src/Seboettg/CiteProc/Locale/Locale.php
+++ b/src/Seboettg/CiteProc/Locale/Locale.php
@@ -54,7 +54,10 @@ class Locale
 
     public function addXml(\SimpleXMLElement $xml)
     {
-        $this->parseXml($xml);
+        $lang = (string) $xml->attributes('http://www.w3.org/XML/1998/namespace')->{'lang'};
+        if (empty($lang) || $this->getLanguage() === $lang || explode('-', $this->getLanguage())[0] === $lang) {
+            $this->parseXml($xml);
+        }
         return $this;
     }
 

--- a/tests/fixtures/basic-tests/processor-tests/humans/locale_OverrideOnlyCurrentLang.txt
+++ b/tests/fixtures/basic-tests/processor-tests/humans/locale_OverrideOnlyCurrentLang.txt
@@ -1,0 +1,50 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+
+
+>>===== RESULT =====>>
+English
+<<===== RESULT =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2009-08-10T04:49:00+09:00</updated>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="from">English</term>
+    </terms>
+  </locale>
+  <locale xml:lang="es">
+    <terms>
+      <term name="from">Spanish</term>
+    </terms>
+  </locale>
+  <citation>
+    <layout>
+      <text term="from"/>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1", 
+        "title": "Sample Title", 
+        "type": "book"
+    }
+]
+<<===== INPUT =====<<

--- a/tests/src/Seboettg/CiteProc/CiteProcTest.php
+++ b/tests/src/Seboettg/CiteProc/CiteProcTest.php
@@ -211,4 +211,9 @@ class CiteProcTest extends TestCase
         $this->assertEquals("[1,3]", $result[0]);
         $this->assertEquals("[2]", $result[1]);
     }
+
+    public function testOverrideOnlyCurrentLang()
+    {
+        $this->_testRenderTestSuite("locale_OverrideOnlyCurrentLang");
+    }
 }


### PR DESCRIPTION
When a locale in a specific style is added to, the additions were not
being filtered based on the current language of the Locale object. This
would cause incorrect translations to be selected (for instance, "de"
instead of "from" in the APA style).