### PR TITLE
Guard against unset variable

### DIFF
--- a/src/Seboettg/CiteProc/Rendering/Label.php
+++ b/src/Seboettg/CiteProc/Rendering/Label.php
@@ -128,7 +128,7 @@ class Label implements Rendering
      */
     private function evaluateStringPluralism($data, $variable)
     {
-        $str = $data->{$variable};
+        $str = isset($data->{$variable}) ? $data->{$variable} : '';
         $plural = 'single';
         if (!empty($str)) {
             switch ($variable) {


### PR DESCRIPTION
Ensure that if evaluateStringPluralism is called with an unset variable
key PHP doesn't emit any notices.

I'm not 100% sure if this is the correct fix or if the calling code ([`Label::getPlural`](https://github.com/umn-ici/citeproc-php/blob/82bdde4fc3151e3727685e40916ed7c1ba52fe66/src/Seboettg/CiteProc/Rendering/Label.php#L167)) should be adjusted. I've only seen this happen with `editortranslator` which I believe is a special key.