### PR TITLE
Add loading of primary dialect

### DIFF
--- a/src/Seboettg/CiteProc/StyleSheet.php
+++ b/src/Seboettg/CiteProc/StyleSheet.php
@@ -46,7 +46,22 @@ class StyleSheet
     public static function loadLocales($langKey)
     {
         $localesPath = self::vendorPath() . "/citation-style-language/locales/";
-        return file_get_contents($localesPath . "locales-" . $langKey . '.xml');
+        $data = @file_get_contents($localesPath . "locales-" . $langKey . '.xml');
+
+        if ($data === false) {
+            $metadata = self::loadLocalesMetadata();
+            if (!empty($metadata->{'primary-dialects'}->{$langKey})) {
+            $data = file_get_contents($localesPath . "locales-" . $metadata->{'primary-dialects'}->{$langKey} . '.xml');
+            }
+        }
+
+        return $data;
+    }
+
+    public static function loadLocalesMetadata()
+    {
+        $localesMetadataPath = self::vendorPath() . "/citation-style-language/locales/locales.json";
+        return json_decode(file_get_contents($localesMetadataPath));
     }
 
     /**

--- a/tests/src/Seboettg/CiteProc/StyleSheetTest.php
+++ b/tests/src/Seboettg/CiteProc/StyleSheetTest.php
@@ -59,4 +59,38 @@ class StyleSheetTest extends TestCase
         }
 
     }
+
+    /**
+     * @coversNothing
+     */
+    public function testLoadLocalesMetadata()
+    {
+
+        $metadata = StyleSheet::loadLocalesMetadata();
+        $this->assertObjectHasAttribute('primary-dialects', $metadata);
+        $this->assertObjectHasAttribute('en', $metadata->{'primary-dialects'});
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function testLoadPrimaryDialectLocale()
+    {
+
+        $locales = StyleSheet::loadLocales("de");
+        $xmlLocales = new \SimpleXMLElement($locales);
+        foreach ($xmlLocales as $child) {
+            if ($child->getName() === "terms") {
+                foreach ($child as $term) {
+                    echo $term["name"];
+                    if ("and" === (string) $term["name"]) {
+                        $this->assertEquals("und", (string) $term);
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+
+    }
 }


### PR DESCRIPTION
By using the `locales.json` file that is provided by the locales repository, we can automatically pick a default dialect when none is provided. This allows consuming code to simply specify `en` for `$langKey` and `en-US` will automatically be picked.