### PR TITLE
Don't show "et-al" text for citation witch don't reach et-al number

### DIFF
--- a/src/Seboettg/CiteProc/Rendering/Name/Name.php
+++ b/src/Seboettg/CiteProc/Rendering/Name/Name.php
@@ -250,7 +250,8 @@ class Name implements HasParent
             !empty($resultNames) &&
             !empty($this->etAl) &&
             !empty($this->etAlMin) &&
-            !empty($this->etAlUseFirst)
+            !empty($this->etAlUseFirst) &&
+            count($data) != count($resultNames)
         ) {
 
 


### PR DESCRIPTION
When we have multiple citation and first citation have more authors then "et-al-min" all other next citations will have this text (et al).

Problem here is because "$this->etAl" is not defined on the start (witch is good) and after we define this parameter we never remove previous value and all next citation will we have this parameters.