### PR TITLE
Call to a member function getRangeDelimiter() on null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,14 @@
         "issues": "https://github.com/seboettg/citeproc-php/issues"
     },
     "autoload": {
-        "psr-4": {"": "src/"}
+        "psr-4": {
+            "Seboettg\\": "src/Seboettg/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Seboettg\\": "tests/src/Seboettg/"
+        }
     },
     "require": {
         "seboettg/collection": "^1.2",

--- a/src/Seboettg/CiteProc/Rendering/Date/Date.php
+++ b/src/Seboettg/CiteProc/Rendering/Date/Date.php
@@ -33,7 +33,7 @@ class Date
         FormattingTrait,
         TextCaseTrait;
 
-    // ymd
+    // bitmask: ymd
     const DATE_RANGE_STATE_NONE         = 0; // 000
     const DATE_RANGE_STATE_DAY          = 1; // 001
     const DATE_RANGE_STATE_MONTH        = 2; // 010
@@ -148,24 +148,13 @@ class Date
         locale-specific, are not allowed on these cs:date-part elements. */
 
         if ($this->dateParts->count() > 0) {
-
-            /* if (isset($var->raw) && !preg_match("/(\p{L}+)\s?([\-\-\&,])\s?(\p{L}+)/u", $var->raw) && $this->dateParts->count() > 0) {
-                //$var->{"date-parts"} = [];
-            } else*/
             if (!isset($var->{'date-parts'})) { // ignore empty date-parts
                 return "";
             }
 
             if (count($data->{$this->variable}->{'date-parts'}) === 1) {
                 $data_ = $this->createDateTime($data->{$this->variable}->{'date-parts'});
-                /** @var DatePart $datePart */
-                foreach ($this->dateParts as $key => $datePart) {
-                    /** @noinspection PhpUnusedLocalVariableInspection */
-                    list($f, $p) = explode("-", $key);
-                    if (in_array($p, $dateParts)) {
-                        $ret .= $datePart->render($data_[0], $this);
-                    }
-                }
+                $ret .= $this->iterateAndRenderDateParts($dateParts, $data_);
             } else if (count($var->{'date-parts'}) === 2) { //date range
                 $data_ = $this->createDateTime($var->{'date-parts'});
                 $from = $data_[0];
@@ -186,15 +175,9 @@ class Date
                     $delim = $this->dateParts->get($this->form . "-day")->getRangeDelimiter();
                 }
                 if ($toRender === self::DATE_RANGE_STATE_NONE) {
-                    foreach ($this->dateParts as $key => $datePart) {
-                        /* @noinspection PhpUnusedLocalVariableInspection */
-                        list($f, $p) = explode("-", $key);
-                        if (in_array($p, $dateParts)) {
-                            $ret .= $datePart->render($data_[0], $this);
-                        }
-                    }
+                    $ret .= $this->iterateAndRenderDateParts($dateParts, $data_);
                 } else {
-                      $ret = $this->renderDateRange($toRender, $from, $to, $delim);
+                    $ret .= $this->renderDateRange($toRender, $from, $to, $delim);
                 }
             }
 
@@ -533,6 +516,25 @@ class Date
         $ret = [];
         foreach ($date as $key => $datePart) {
             $ret[$key] = Util\NumberHelper::extractNumber(Util\StringHelper::removeBrackets($datePart));
+        }
+        return $ret;
+    }
+
+    /**
+     * @param array $dateParts
+     * @param array $data_
+     * @return string
+     */
+    private function iterateAndRenderDateParts(array $dateParts, array $data_)
+    {
+        $ret = "";
+        /** @var DatePart $datePart */
+        foreach ($this->dateParts as $key => $datePart) {
+            /** @noinspection PhpUnusedLocalVariableInspection */
+            list($f, $p) = explode("-", $key);
+            if (in_array($p, $dateParts)) {
+                $ret .= $datePart->render($data_[0], $this);
+            }
         }
         return $ret;
     }

--- a/src/Seboettg/CiteProc/Rendering/Date/Date.php
+++ b/src/Seboettg/CiteProc/Rendering/Date/Date.php
@@ -173,20 +173,30 @@ class Date
                 $interval = $to->diff($from);
                 $delim = "";
                 $toRender = 0;
-                if ($interval->y > 0) {
+                if ($interval->y > 0 && in_array('year', $dateParts)) {
                     $toRender |= self::DATE_RANGE_STATE_YEAR;
                     $delim = $this->dateParts->get($this->form . "-year")->getRangeDelimiter();
                 }
-                if ($interval->m > 0 && $from->getMonth() - $to->getMonth() !== 0) {
+                if ($interval->m > 0 && $from->getMonth() - $to->getMonth() !== 0 && in_array('month', $dateParts)) {
                     $toRender |= self::DATE_RANGE_STATE_MONTH;
                     $delim = $this->dateParts->get($this->form . "-month")->getRangeDelimiter();
                 }
-                if ($interval->d > 0 && $from->getDay() - $to->getDay() !== 0) {
+                if ($interval->d > 0 && $from->getDay() - $to->getDay() !== 0 && in_array('day', $dateParts)) {
                     $toRender |= self::DATE_RANGE_STATE_DAY;
                     $delim = $this->dateParts->get($this->form . "-day")->getRangeDelimiter();
                 }
-
-                $ret = $this->renderDateRange($toRender, $from, $to, $delim);
+                if ($toRender === self::DATE_RANGE_STATE_NONE) {
+                  foreach ($this->dateParts as $key => $datePart) {
+                    /** @noinspection PhpUnusedLocalVariableInspection */
+                    list($f, $p) = explode("-", $key);
+                    if (in_array($p, $dateParts)) {
+                      $ret .= $datePart->render($data_[0], $this);
+                    }
+                  }
+                }
+                else {
+                  $ret = $this->renderDateRange($toRender, $from, $to, $delim);
+                }
             }
 
             if (isset($var->raw) && preg_match("/(\p{L}+)\s?([\-\-\&,])\s?(\p{L}+)/u", $var->raw, $matches)) {

--- a/src/Seboettg/CiteProc/Rendering/Date/Date.php
+++ b/src/Seboettg/CiteProc/Rendering/Date/Date.php
@@ -186,16 +186,15 @@ class Date
                     $delim = $this->dateParts->get($this->form . "-day")->getRangeDelimiter();
                 }
                 if ($toRender === self::DATE_RANGE_STATE_NONE) {
-                  foreach ($this->dateParts as $key => $datePart) {
-                    /** @noinspection PhpUnusedLocalVariableInspection */
-                    list($f, $p) = explode("-", $key);
-                    if (in_array($p, $dateParts)) {
-                      $ret .= $datePart->render($data_[0], $this);
+                    foreach ($this->dateParts as $key => $datePart) {
+                        /* @noinspection PhpUnusedLocalVariableInspection */
+                        list($f, $p) = explode("-", $key);
+                        if (in_array($p, $dateParts)) {
+                            $ret .= $datePart->render($data_[0], $this);
+                        }
                     }
-                  }
-                }
-                else {
-                  $ret = $this->renderDateRange($toRender, $from, $to, $delim);
+                } else {
+                      $ret = $this->renderDateRange($toRender, $from, $to, $delim);
                 }
             }
 

--- a/tests/fixtures/basic-tests/processor-tests/humans/bugfix-github-dates-minimal.txt
+++ b/tests/fixtures/basic-tests/processor-tests/humans/bugfix-github-dates-minimal.txt
@@ -1,0 +1,52 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== RESULT =====>>
+2004
+<<===== RESULT =====<<
+
+
+>>===== CSL =====>>
+<style 
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2009-08-10T04:49:00+09:00</updated>
+  </info>
+  <citation>
+    <layout delimiter="; ">
+       <date variable="issued" form="text" date-parts="year"/>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1", 
+        "issued": {
+            "date-parts": [
+                [
+                    2004, 
+                    10, 
+                    21
+                ], 
+                [
+                    2004, 
+                    10, 
+                    23
+                ]
+            ]
+        }, 
+        "title": "Some Book or Other", 
+        "type": "book"
+    }
+]
+<<===== INPUT =====<<

--- a/tests/fixtures/basic-tests/processor-tests/humans/bugfix-github-dates.txt
+++ b/tests/fixtures/basic-tests/processor-tests/humans/bugfix-github-dates.txt
@@ -1,0 +1,515 @@
+>>===== MODE =====>>
+bibliography
+<<===== MODE =====<<
+
+
+
+>>===== RESULT =====>>
+<div class="csl-bib-body">
+  <div class="csl-entry">Gebremedhin, M. T. (2004). Carbon dioxide and energy balance of a double cropping agroecosystem in northern Alabama climate.</div>
+</div>
+<<===== RESULT =====<<
+
+
+>>===== CSL =====>>
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
+  <info>
+    <title>American Psychological Association 6th edition</title>
+    <title-short>APA</title-short>
+    <id>http://www.zotero.org/styles/apa</id>
+    <link href="http://www.zotero.org/styles/apa" rel="self"/>
+    <link href="http://owl.english.purdue.edu/owl/resource/560/01/" rel="documentation"/>
+    <author>
+      <name>Simon Kornblith</name>
+      <email>simon@simonster.com</email>
+    </author>
+    <contributor>
+      <name>Bruce D'Arcus</name>
+    </contributor>
+    <contributor>
+      <name>Curtis M. Humphrey</name>
+    </contributor>
+    <contributor>
+      <name>Richard Karnesky</name>
+      <email>karnesky+zotero@gmail.com</email>
+      <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
+    </contributor>
+    <contributor>
+      <name>Sebastian Karcher</name>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="psychology"/>
+    <category field="generic-base"/>
+    <updated>2013-09-21T18:17:09+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>trans.</single>
+        <multiple>trans.</multiple>
+      </term>
+    </terms>
+  </locale>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor translator" delimiter=", " suffix=", ">
+          <name and="symbol" initialize-with=". " delimiter=", "/>
+          <label form="short" prefix=" (" text-case="title" suffix=")"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="article-journal chapter paper-conference" match="none">
+        <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
+          <name and="symbol" initialize-with=". " delimiter=", "/>
+          <label form="short" prefix=", " text-case="title"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </else-if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if variable="archive" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="archive" suffix="."/>
+              <text variable="archive_location" prefix=" (" suffix=")"/>
+            </group>
+          </if>
+          <else>
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="doi:"/>
+          </if>
+          <else>
+            <choose>
+              <if type="webpage">
+                <group delimiter=" ">
+                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                  <group>
+                    <date variable="accessed" form="text" suffix=", "/>
+                  </group>
+                  <text term="from"/>
+                  <text variable="URL"/>
+                </group>
+              </if>
+              <else>
+                <group>
+                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                  <text term="from" suffix=" "/>
+                  <text variable="URL"/>
+                </group>
+              </else>
+            </choose>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="report thesis" match="any">
+        <text variable="title" font-style="italic"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="genre"/>
+          <text variable="number" prefix="No. "/>
+        </group>
+      </if>
+      <else-if type="book graphic  motion_picture report song manuscript speech" match="any">
+        <!---This is a hack until we have a computer program type -->
+        <choose>
+          <if variable="version">
+            <group delimiter=" ">
+              <text variable="title"/>
+              <group delimiter=" " prefix="(" suffix=")">
+                <text term="version" text-case="capitalize-first"/>
+                <text variable="version"/>
+              </group>
+            </group>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="report" match="any">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else-if type="thesis" match="any">
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <choose>
+            <if variable="event" match="none">
+              <text variable="genre"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="article-journal article-magazine" match="none">
+              <group delimiter=": ">
+                <text variable="publisher-place"/>
+                <text variable="publisher"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="container-title" match="none">
+        <choose>
+          <if variable="event">
+            <choose>
+              <if variable="genre" match="none">
+                <text term="presented at" text-case="capitalize-first" suffix=" "/>
+                <text variable="event"/>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <text term="presented at"/>
+                  <text variable="event"/>
+                </group>
+              </else>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="issued">
+            <group prefix=" (" suffix=")">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <choose>
+                <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+                  <date variable="issued">
+                    <date-part prefix=", " name="month"/>
+                    <date-part prefix=" " name="day"/>
+                  </date>
+                </if>
+              </choose>
+            </group>
+          </if>
+          <else>
+            <group prefix=" (" suffix=")">
+              <text term="no date" form="short"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month"/>
+          <date-part name="day"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <text variable="year-suffix"/>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <group prefix=", " delimiter=", ">
+          <group>
+            <text variable="volume" font-style="italic"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else-if type="article-newspaper">
+        <group delimiter=" " prefix=", ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="book graphic motion_picture report song chapter paper-conference" match="any">
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <text macro="edition"/>
+          <group>
+            <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
+            <number variable="number-of-volumes" form="numeric" prefix="1-"/>
+          </group>
+          <group>
+            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group>
+            <label variable="page" form="short" suffix=" "/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="legal_case">
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="authority"/>
+          <date variable="issued" form="text"/>
+        </group>
+      </else-if>
+      <else-if type="bill legislation" match="any">
+        <date variable="issued" prefix=" (" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <choose>
+        <if locator="chapter">
+          <label variable="locator" form="long" text-case="capitalize-first"/>
+        </if>
+        <else>
+          <label variable="locator" form="short"/>
+        </else>
+      </choose>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="container">
+    <group>
+      <choose>
+        <if type="chapter paper-conference entry-encyclopedia" match="any">
+          <text term="in" text-case="capitalize-first" suffix=" "/>
+        </if>
+      </choose>
+      <text macro="container-contributors"/>
+      <text macro="secondary-contributors"/>
+      <text macro="container-title"/>
+    </group>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper" match="any">
+        <text variable="container-title" font-style="italic" text-case="title"/>
+      </if>
+      <else-if type="bill legal_case legislation" match="none">
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+      <else>
+        <group delimiter=" " prefix=", ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <text variable="page"/>
+            </if>
+            <else>
+              <choose>
+                <if type="legal_case">
+                  <text variable="number" prefix="No. "/>
+                </if>
+                <else>
+                  <text variable="number" prefix="Pub. L. No. "/>
+                  <group delimiter=" ">
+                    <!--change to label variable="section" as that becomes available -->
+                    <text term="section" form="symbol"/>
+                    <text variable="section"/>
+                  </group>
+                </else>
+              </choose>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued-year"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="6" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort" sort="ascending"/>
+      <key macro="title"/>
+    </sort>
+    <layout>
+      <group suffix=".">
+        <group delimiter=". ">
+          <text macro="author"/>
+          <text macro="issued"/>
+          <text macro="title" prefix=" "/>
+          <text macro="container"/>
+        </group>
+        <text macro="locators"/>
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </group>
+      <text macro="access" prefix=" "/>
+    </layout>
+  </bibliography>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "abstract": "Minimum tillage along with crop residue management on a double cropping system is recognized as practical choice of soil carbon management option in several crop production regions across the US. Here, seasonal estimates of net ecosystem exchange (NEE) and its components for soybean and winter wheat crops (double cropping systems) were studied at Winfred Thomas Agricultural Research Station (WTARS) in Hazel green Alabama for growing seasons of 2007, 2008 and 2009 using the eddy covariance technique. The site was a net annual source of carbon during the year 2007 and 2008 (cumulative NEE ca. 100 and 30 g C m⁻² y⁻¹), while 2009 was a slight C sink (-20 g C m⁻² y⁻¹). Here, differential soil and canopy respiratory looses have played significant role in the annual crop C status. The soybean-winter wheat double cropping system of northern Alabama studied here exhibited a contrasting LE, H and G flux patterns. driven by biophysical attributes, crop phenology and by management. Seasonally integrated evapo transpiration values for soybean were 220, 258 and 276 mm in 2007, 2008 and 2009, respectively reflective of precipitation driven canopy-atmosphere water cycling with corresponding precipitations of 260, 304, 753 mm. With the exception of winter growing season of 2007, which was smaller, ET of winter cover crop (winter wheat) was higher by 15% and 26% than soybean. For soybean, the percentage of water returned to the atmosphere via ET relative to growing season precipitation was the highest in 2007 (85%) received during growing cycle\"--page vi.", 
+        "author": [
+            {
+                "family": "Gebremedhin", 
+                "given": "Maheteme T."
+            }
+        ], 
+        "call-number": "S603.7 .G43 2010", 
+        "issued": {
+            "date-parts": [
+                [
+                    "2004", 
+                    "10", 
+                    21
+                ], 
+                [
+                    "2004", 
+                    "10", 
+                    23
+                ]
+            ]
+        }, 
+        "note": "1. Maheteme T. Gebremedhin.  2. Ph. D. Alabama A & M University 2010.  3. Includes bibliographical references (leaves 191-200).  ", 
+        "publisher": "Alabama A&M University", 
+        "publisher-place": "alu", 
+        "title": "Carbon dioxide and energy balance of a double cropping agroecosystem in northern Alabama climate", 
+        "type": "article-journal"
+    }
+]
+<<===== INPUT =====<<

--- a/tests/src/Seboettg/CiteProc/BugfixTest.php
+++ b/tests/src/Seboettg/CiteProc/BugfixTest.php
@@ -23,7 +23,7 @@ class BugfixTest extends TestCase
 
     public function testBugfixGithub()
     {
-        $this->_testRenderTestSuite("bugfix-github", ["bugfix-github-58"]);
+        $this->_testRenderTestSuite("bugfix-github", ["bugfix-github-58", "bugfix-github-date"]);
     }
 
     /**
@@ -41,6 +41,9 @@ class BugfixTest extends TestCase
         $this->assertTrue(isset($input[0]->title), "Failed asserting that title property exists in input data");
     }
 
+    /**
+     * @throws Exception\CiteProcException
+     */
     public function testBugfixGitub59()
     {
         $style = "modern-language-association";
@@ -51,5 +54,10 @@ class BugfixTest extends TestCase
         $this->assertNotTrue(isset($datum->author)); //first entry has no author
         $result = $citeProc->render($data);
         $this->assertNotEmpty($result);
+    }
+
+    public function testBugfixGithubDate()
+    {
+        $this->_testRenderTestSuite("bugfix-github-date");
     }
 }


### PR DESCRIPTION
## Issue

I was seeing a fatal error while calling into this library from my code:
```
Error: Call to a member function getRangeDelimiter() on null in Seboettg\CiteProc\Rendering\Date\Date->render()
```

## Test cases

I have added two new test cases in this PR, both were failing previously:
[bugfix-github-dates-minimal.txt](https://github.com/seboettg/citeproc-php/pull/64/files#diff-b27da91c71df2aac6f24a49ba2fda1e2)
In this case the whole date was rendering, instead of just the datepart specified in the CSL.
```
--- Expected
+++ Actual
@@ @@
-'2004'
+'October 21–23, 2004'
```


[bugfix-github-dates.txt](https://github.com/seboettg/citeproc-php/pull/64/files#diff-0f759ac291f0d26a01e13dcab117efa8)
In this case I was getting a fatal error
```
Error: Call to a member function getRangeDelimiter() on null in Seboettg\CiteProc\Rendering\Date\Date->render()
```

## Fix

The fix here was two-fold, one was to ensure the part of the date range we are rendering is actually specified in the CSL, and the other is to fall back to normal date rendering if the part of the date required in the CSL is not actually part of the date range.

## Additional Notes:

Any feedback on this fix would be much appreciated, I would like to see it merged into the project as this case is causing issues for one of the users of my software that calls out to this library. Also thank you for building and maintaining this very useful library. 

## Interested parties

@seboettg