### PR TITLE
No whitespace between given and family names of authors/editors

### DIFF
--- a/src/Rendering/Name/Name.php
+++ b/src/Rendering/Name/Name.php
@@ -583,10 +583,11 @@ class Name implements HasParent
                 list($family, $given) = $this->renderNameParts($data);
                 $text = !empty($given) ? $given . " " . $family : $family;
             }
+        } else if (StringHelper::isAsianString(NameHelper::normalizeName($data))) {
+            $text = $this->form === "long" ? $data->family . $data->given : $data->family;
         } else {
             $text = $this->form === "long" ? $data->family . " " . $data->given : $data->family;
         }
-
         return $text;
     }
 

--- a/src/Rendering/Name/Name.php
+++ b/src/Rendering/Name/Name.php
@@ -584,7 +584,7 @@ class Name implements HasParent
                 $text = !empty($given) ? $given . " " . $family : $family;
             }
         } else {
-            $text = $this->form === "long" ? $data->family.$data->given : $data->family;
+            $text = $this->form === "long" ? $data->family . " " . $data->given : $data->family;
         }
 
         return $text;

--- a/src/Util/StringHelper.php
+++ b/src/Util/StringHelper.php
@@ -249,6 +249,15 @@ class StringHelper
     }
 
     /**
+     * @param $string
+     * @return bool
+     */
+    public static function isAsianString($string)
+    {
+        return boolval(preg_match("/^[\p{Han}\s\p{P}]*$/u", $string));
+    }
+
+    /**
      * removes all kind of brackets from a given string
      * @param $datePart
      * @return mixed


### PR DESCRIPTION
Hello @seboettg !

I had an issue with a few citation stylesheets, where the family and given name are not seperated by a space or anything. The ones I had an issue with where:
[Springer LNCS](https://github.com/citation-style-language/styles/blob/master/springer-lecture-notes-in-computer-science.csl)
Result:
1.
DoeJ.: My Anonymous Heritage. (2001).
2.
AndersonJ., BrownJ.: Two authors writing a book. (1998).
3.
ColeS.J., MooreR.: Hydrological modelling using raingauge- and radar-based estimators of areal rainfall. Journal of Hydrology. 358, 159-181 (2008). https://doi.org/10.1016/j.jhydrol.2008.05.025.
4.
BenzD., HothoA., JäschkeR., StummeG., HalleA., LimaA.G.S., SteenwegH., StefaniS., DietrichB.: Academic Publication Management with PUMA - collect, organize and share publications. In: Proceedings of the European Conference on Research and Advanced Technology for Digital Libraries. p. 417-420. Springer, Berlin/Heidelberg (2010).

[APA](https://github.com/citation-style-language/styles/blob/master/apa.csl)
Result:
AndersonJ., & BrownJ. (1998). Two authors writing a book.
BenzD., HothoA., JäschkeR., StummeG., HalleA., LimaA. G. S., SteenwegH., StefaniS., & DietrichB. (2010). Academic Publication Management with PUMA - collect, organize and share publications. Proceedings of the European Conference on Research and Advanced Technology for Digital Libraries, 6273, 417-420. Berlin/Heidelberg: Springer.
ColeS. J., & MooreR. (2008). Hydrological modelling using raingauge- and radar-based estimators of areal rainfall. Journal of Hydrology, 358(3-4), 159-181. https://doi.org/10.1016/j.jhydrol.2008.05.025
DoeJ. (2001). My Anonymous Heritage.

[Harvard Cite them right](https://github.com/citation-style-language/styles/blob/master/harvard-cite-them-right.csl)
Result:
AndersonJ. and BrownJ. (1998) Two authors writing a book.
BenzD., HothoA., JäschkeR., StummeG., HalleA., LimaA. G. S., SteenwegH., StefaniS. and DietrichB. (2010) “Academic Publication Management with PUMA - collect, organize and share publications”, in Proceedings of the European Conference on Research and Advanced Technology for Digital Libraries. Berlin/Heidelberg: Springer (Lecture Notes in Computer Science), p. 417-420.
ColeS. J. and MooreR. (2008) “Hydrological modelling using raingauge- and radar-based estimators of areal rainfall”, Journal of Hydrology, 358(3-4), pp. 159-181. doi: 10.1016/j.jhydrol.2008.05.025.
DoeJ. (2001) My Anonymous Heritage.

I am not sure, if it's just an issue on my side, since I am having similiar results with other .csl's as well, but didn't find an previous issue like that in the repositorie's issue section.
Though the small change resolved the issue for all the citation styles I tried to use.