### PR TITLE
Change symfony/polyfill-mbstring requirement from v1.10.* to ^1.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "seboettg/collection": "^1.2",
         "myclabs/php-enum": "^1.5",
-        "symfony/polyfill-mbstring": "v1.10.*",
+        "symfony/polyfill-mbstring": "^1.10",
         "ext-simplexml": "*",
         "ext-json": "*",
         "ext-intl": "*"


### PR DESCRIPTION
You already have 2 failing tests on master (tag 2.2.0). This change does not cause any more of them to fail, and it solves #85 .