### PR TITLE
Remove intl platform dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "symfony/polyfill-mbstring": "^1.10",
         "ext-simplexml": "*",
         "ext-json": "*",
-        "ext-intl": "*",
         "php": ">=7.1"
     },
     "require-dev": {


### PR DESCRIPTION
Is the intl extension required for anything? I see it was added in [this commit](https://github.com/seboettg/citeproc-php/commit/0ff576e8ccf7ecc1eff925b1d3ff2fdf773b022f) but I don't see any function calls on the intl package.

I'm asking because when using this library on a Drupal 9 site, our hosting provide does not have the intl extension available and they are unable to enable it.