### PR TITLE
FIX: broken instanciation of Context due to passing wrong parameter

### DIFF
--- a/src/CiteProc.php
+++ b/src/CiteProc.php
@@ -205,7 +205,7 @@ class CiteProc
      */
     public function init($citationAsArray = false)
     {
-        self::$context = new Context($this);
+        self::$context = new Context();
         self::$context->setLocale(new Locale\Locale($this->lang)); //init locale
         self::$context->setCitationsAsArray($citationAsArray);
         // set markup extensions


### PR DESCRIPTION
Had the issue that `self::$context` was null directly after instanciation. That's probably due to the wrong type of the parameter passed to the constructor that should be of type `Locale` and not `CiteProc`.