### PR TITLE
Fix php notice for php8.1+ about DateTime::setDate return type

### DIFF
--- a/src/Rendering/Date/DateTime.php
+++ b/src/Rendering/Date/DateTime.php
@@ -86,6 +86,7 @@ class DateTime extends \DateTime
      * @param int $day
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setDate($year, $month, $day)
     {
         $this->year = $year;


### PR DESCRIPTION
I'm using PHP 8.1.2 and PHP 8.1.7 versions with your great library. 
I found a small issue:
`Deprecated function: Return type of Seboettg\CiteProc\Rendering\Date\DateTime::setDate($year, $month, $day) should either be compatible with DateTime::setDate(int $year, int $month, int $day): DateTime, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 480 of /var/www/vendor/composer/ClassLoader.php).`

To fix it and have compatibility with older PHP versions we just need to add 1 line to your overridden setDate function.