### PR TITLE
Hotfix/2.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "citation-style-language/styles": "v0.0.*",
         "citation-style-language/locales": "v0.0.*",
-        "seboettg/collection": ">=v3.1.0",
+        "seboettg/collection": "^3.1",
         "myclabs/php-enum": "^1.8",
         "ext-simplexml": "*",
         "ext-json": "*",


### PR DESCRIPTION
This fixates the version of `seboettg/collection` library to `>=3.1 <4.0`.