### PR TITLE
Fix fatal error when encountering non-numeric "page" values

### DIFF
--- a/src/Util/PageHelper.php
+++ b/src/Util/PageHelper.php
@@ -27,7 +27,10 @@ class PageHelper
     {
         list($from, $to) = $ranges;
 
-        if (!empty($pageRangeFormat)) {
+        // We check to see if the page values are numeric since it is now 
+        // common to encounter electronic identifiers 'E123-45' which will
+        // throw TypeErrors if we try and process them below.
+        if (!empty($pageRangeFormat) && is_numeric($from) && is_numeric($to)) {
             switch ($pageRangeFormat) {
                 case PageRangeFormats::MINIMAL:
                     $resTo = self::renderMinimal($from, $to, 0);


### PR DESCRIPTION
See: https://github.com/seboettg/citeproc-php/issues/144

Example page value that will cause an issue: E123-45