### PR TITLE
Attempt to fix issue #141.

### DIFF
--- a/src/Util/StringHelper.php
+++ b/src/Util/StringHelper.php
@@ -85,7 +85,7 @@ class StringHelper
 
     const CONJUNCTIONS = [
         'and',     // en
-        "et",      // fr 
+        "et",      // fr
         'nor',     // en
         'or',      // en
         'ou',      // fr
@@ -176,7 +176,7 @@ class StringHelper
         $wordArray = preg_split($pattern, $titleString); //explode(" ", $titleString);
 
         $wordList = new ArrayList(...$wordArray);
-        return $wordList
+        $convertedString = $wordList
             ->map(function(string $word) {
                 $wordParts = explode("-", $word);
                 if (count($wordParts) > 1) {
@@ -187,8 +187,36 @@ class StringHelper
                     $word = implode("-", $casedWordParts);
                 }
                 return StringHelper::keepLowerCase($word) ? $word : StringHelper::mb_ucfirst($word);
-            })
-            ->collectToString($delimiter);
+            })->collectToString($delimiter);
+
+        return self::replaceDelimeters($titleString, $convertedString);
+    }
+
+    /**
+     * Compare two strings, return a new string that uses the characters of the
+     * first string and the capitalizations from the second string.
+     *
+     * For example, given the strings "hello worlD" and "Hello/WORLD", the
+     * function will return "Hello WORLD".
+     *
+     * @param string $original
+     * @param string $converted
+     *
+     * @return string
+     */
+    private static function replaceDelimeters(string $original, string $converted): string {
+        $result = "";
+
+        $originalChars = str_split($original);
+        $convertedChars = str_split($converted);
+
+        foreach($originalChars as $i => $char) {
+            $result .= mb_strtolower($char) === mb_strtolower($convertedChars[$i])
+              ? $convertedChars[$i]
+              : $char;
+        }
+
+        return $result;
     }
 
     /**
@@ -202,7 +230,7 @@ class StringHelper
         // because of static, compilation is done only one time
         if ($lcDic === null) {
             $lcDic = array_flip(array_merge(
-                self::PREPOSITIONS, 
+                self::PREPOSITIONS,
                 self::ARTICLES,
                 self::ADVERBS,
                 self::CONJUNCTIONS,

--- a/tests/src/Util/StringHelperTest.php
+++ b/tests/src/Util/StringHelperTest.php
@@ -67,4 +67,26 @@ class StringHelperTest extends TestCase
         static::assertFalse(StringHelper::isCyrillicString("Nicht"));
         static::assertFalse(StringHelper::isCyrillicString("пеpеводчиком"));
     }
+
+    public function testCapitalizeForTitle(){
+
+        $testItems = [
+            ["test"=> "Hello/wORLD", "expected" => "Hello/WORLD"],
+            ["test"=> "Title/with a slash", "expected" => "Title/With a Slash"],
+            ["test"=> "Title/with two/ slashes", "expected" => "Title/With Two/ Slashes"],
+            ["test"=> "///Title/with Consecutive/ slashes", "expected" => "///Title/With Consecutive/ Slashes"],
+            ["test"=> "/\/|/Title/with wierd/ slashes", "expected" => "/\/|/Title/With Wierd/ Slashes"],
+            ["test"=> "?/\/|/Title/with Consecutive/ slashes", "expected" => "?/\/|/Title/With Consecutive/ Slashes"],
+            ["test"=> "?/\/|/Title/with /Consecutive/ slashes", "expected" => "?/\/|/Title/With /Consecutive/ Slashes"],
+            ["test"=> "?/\/|/Title/with Con/secutive slashes", "expected" => "?/\/|/Title/With Con/Secutive Slashes"],
+            ["test"=> "braintree/Braintree_php", "expected" => "Braintree/Braintree_php"], // issue105
+            ["test"=> "T7/G7 task force", "expected" => "T7/G7 Task Force"], // issue141
+          //["test"=> "ö/ö örb å ø", "expected" => "Ö/Ö Örb Å Ø"], // Doesn't work
+        ];
+
+        foreach($testItems as $item){
+            static::assertEquals($item["expected"], StringHelper::capitalizeForTitle($item["test"]));
+        }
+
+    }
 }


### PR DESCRIPTION
Hi it seems the issue with additional slashes come from the following code:

```php
$pattern = "/(\s|\/)/";

if (!preg_match($pattern, $titleString, $matches)) {
    return StringHelper::mb_ucfirst($titleString);
}

// Here, delimiter could either be whitespace or a slash.
$delimiter = $matches[1];

// Here, the title is split by both whitespate AND a slash.
// If the $delimiter happens to be a slash, then the string will be
// pieced back together by slashes.
$wordArray = preg_split($pattern, $titleString); //explode(" ", $titleString);

```

Without changing the original code, I propose we walk through the converted string, 
and keep the occurrence of a delimiter if they exist in both strings, but replace it 
with the original character (a whitespace) if it doesn't exist in the original string. 

This should be safe but I don't insist on the implementation. Please let me know
your thoughts!

Also, I added some test cases in the unit test for this function. I hope they are useful.
